### PR TITLE
docs(repository): Re-sync metadata of repository

### DIFF
--- a/.repository/index.json
+++ b/.repository/index.json
@@ -21,7 +21,6 @@
     "C++",
     "Dockerfile",
     "Makefile",
-    "Objective-C",
     "Shell"
   ]
 }


### PR DESCRIPTION
Sync the metadata of the repository from GitHub to catch any new language changes.

Some of the automated changes to the repository have altered how the language composition of the repository. This re-syncs the .repository definition file. When cleaning up the gitlab mirroring, this should also be fixed to remove languages from definition.